### PR TITLE
Add backtrace to web view

### DIFF
--- a/lib/sidekiq/failures/views/failures.slim
+++ b/lib/sidekiq/failures/views/failures.slim
@@ -8,17 +8,18 @@ h1 Failed Jobs
       th Worker
       th Args
       th Queue
-      th Exception
-      th Error
       th Failed At
+      th Exception
     - @messages.each do |msg|
       tr
         td= msg['worker']
         td= msg['payload']['args'].inspect[0..100]
         td= msg['queue']
-        td= msg['exception']
-        td= msg['error']
         td= msg['failed_at']
+        td
+          = "#{msg['exception']}: "
+          a.backtrace href="#" onclick="$(this).next().toggle()"  =msg['error']
+          pre style="display:none; font-size: 0.8em" = msg['backtrace'].join("\n")
 
   form.form-horizontal action="#{root_path}failures/remove" method="post"
     input.btn.btn-danger type="submit" name="delete" value="Clear All"


### PR DESCRIPTION
I need to see the backtrace for errors, so I added the a toggle to show the backtrace similar to Resque.

I don't think this way is particularly clean - I put it together quickly just for my own development purposes. If you have any better ideas on how to show the full backtrace, definitely let me know.
