### PR TITLE
Changed order of failures: now new failures are appearing on start of list

### DIFF
--- a/lib/sidekiq/failures/middleware.rb
+++ b/lib/sidekiq/failures/middleware.rb
@@ -14,7 +14,7 @@ module Sidekiq
           :queue => queue
         }
 
-        Sidekiq.redis { |conn| conn.rpush(:failed, Sidekiq.dump_json(data)) }
+        Sidekiq.redis { |conn| conn.lpush(:failed, Sidekiq.dump_json(data)) }
 
         raise
       end


### PR DESCRIPTION
I think this order is much better for tracking, you don't need to jump on last page to see what happened recently.
What do you think guys?
Also sorry for lots of PRs, i decided to make it all separate, maybe something isn't good from your side.
