### PR TITLE
Prevent sidekiq-failures from loading up sidekiq/processor (and thus Celluloid actors) except for inside a Sidekiq server context

### DIFF
--- a/lib/sidekiq/failures.rb
+++ b/lib/sidekiq/failures.rb
@@ -1,5 +1,4 @@
 require "sidekiq/web"
-require "sidekiq/processor"
 require "sidekiq/failures/version"
 require "sidekiq/failures/middleware"
 require "sidekiq/failures/web_extension"
@@ -18,6 +17,8 @@ else
   Sidekiq::Web.tabs["Failures"] = "failures"
 end
 
-Sidekiq.server_middleware do |chain|
-  chain.add Sidekiq::Failures::Middleware
+Sidekiq.configure_server do |config|
+  config.server_middleware do |chain|
+    chain.add Sidekiq::Failures::Middleware
+  end
 end

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -9,6 +9,7 @@ module Sidekiq
         $invokes = 0
         boss = MiniTest::Mock.new
         @processor = ::Sidekiq::Processor.new(boss)
+        Sidekiq.server_middleware {|chain| chain.add Sidekiq::Failures::Middleware }
         Sidekiq.redis = REDIS
         Sidekiq.redis { |c| c.flushdb }
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,7 @@ require "rack/test"
 
 require "sidekiq"
 require "sidekiq-failures"
+require "sidekiq/processor"
 
 Celluloid.logger = nil
 Sidekiq.logger.level = Logger::ERROR


### PR DESCRIPTION
sidekiq-failures currently requires `sidekiq/processor`, which spins up Celluloid actors every time the app is run in any context (rake, app instance, etc), rather than just in the context of a sidekiq server.

This patch simply modifies the way that sidekiq-failures is added to the middleware chain so that it'll only be done as part of the server configuration process, rather than all the time.

Tests pass under ruby 1.9.3p286 (2012-10-12 revision 37165) [x86_64-linux]
