### PR TITLE
Reset stats:failed counter when removing failures.

### DIFF
--- a/lib/sidekiq/failures/web_extension.rb
+++ b/lib/sidekiq/failures/web_extension.rb
@@ -20,7 +20,10 @@ module Sidekiq
         end
 
         app.post "/failures/remove" do
-          Sidekiq.redis {|c| c.del(:failed) }
+          Sidekiq.redis do |redis|
+            redis.del("failed")
+            redis.set("stat:failed", 0)
+          end
 
           redirect "#{root_path}failures"
         end

--- a/test/web_extension_test.rb
+++ b/test/web_extension_test.rb
@@ -62,6 +62,16 @@ module Sidekiq
         last_response.status.must_equal 200
         last_response.body.must_match /No failed jobs found/
       end
+
+      it 'can reset failures stats' do
+        last_response.body.must_match /HardWorker/
+
+        post '/failures/remove'
+        Sidekiq.redis do |redis|
+          assert_equal "0", redis.get("stat:failed")
+        end
+      end
+
     end
 
     def create_sample_failure


### PR DESCRIPTION
When you clear failed jobs in the failures menu, the failed counter does not get updated.

Reseting Redis key "stats:failed" to 0 does the trick.
