### PR TITLE
record_after_max_retries options

### DIFF
--- a/lib/sidekiq/failures.rb
+++ b/lib/sidekiq/failures.rb
@@ -5,6 +5,9 @@ require "sidekiq/failures/web_extension"
 
 module Sidekiq
   module Failures
+    class << self
+      attr_accessor :record_after_max_retries
+    end
   end
 end
 


### PR DESCRIPTION
When flag is enabled, failures only show up when retries have been exhausted.
