### PR TITLE
Render slim views without overloading find_template in sinatra

### DIFF
--- a/lib/sidekiq/failures/web_extension.rb
+++ b/lib/sidekiq/failures/web_extension.rb
@@ -3,20 +3,14 @@ module Sidekiq
     module WebExtension
 
       def self.registered(app)
-        app.helpers do
-          def find_template(view, *a, &b)
-            dir = File.expand_path("../views/", __FILE__)
-            super(dir, *a, &b)
-            super
-          end
-        end
-
         app.get "/failures" do
+          view_path = File.join(File.expand_path("..", __FILE__), "views")
+
           @count = (params[:count] || 25).to_i
           (@current_page, @total_size, @messages) = page("failed", params[:page], @count)
           @messages = @messages.map { |msg| Sidekiq.load_json(msg) }
 
-          slim :failures
+          render(:slim, File.read(File.join(view_path, "failures.slim")))
         end
 
         app.post "/failures/remove" do


### PR DESCRIPTION
This allows sidekiq-failures to work with both sidekiq and sidekiq-pro. All tests are passing.
