### PR TITLE
Use #message instead of #to_s

### DIFF
--- a/lib/sidekiq/failures/middleware.rb
+++ b/lib/sidekiq/failures/middleware.rb
@@ -13,7 +13,7 @@ module Sidekiq
           :failed_at => Time.now.strftime("%Y/%m/%d %H:%M:%S %Z"),
           :payload => msg,
           :exception => e.class.to_s,
-          :error => e.to_s,
+          :error => e.message,
           :backtrace => e.backtrace,
           :worker => msg['class'],
           :queue => queue


### PR DESCRIPTION
Exceptions raised by the google-adwords-api gem return the same thing for `e.class.to_s` and `e.to_s`. Switching to `message` here makes the output match what is shown in sidekiq's retries. I believe the convention is to implement a `message` method on exceptions, so I'm thinking this issue isn't specific to this gem.
