### PR TITLE
added "rotating" failures list

### DIFF
--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -130,6 +130,21 @@ module Sidekiq
         assert_equal 1, $invokes
       end
 
+      it "remove old failures when max_failure_count has been reached" do
+        Sidekiq.max_failures_count = 2
+
+        msg = create_work('class' => MockWorker.to_s, 'args' => ['myarg'])
+
+        assert_equal 0, failures_count
+        
+        3.times do
+          assert_raises TestException do
+            ::Sidekiq::Processor.new(MiniTest::Mock.new).process(msg)
+          end
+        end
+        assert_equal 2, failures_count
+      end
+
       def failures_count
         Sidekiq.redis { |conn|conn.llen('failed') } || 0
       end


### PR DESCRIPTION
Just to avoid to surcharge redis with fail jobs.

I had a wrong configuration of my db ip and all my jobs fails causing more than 1 000 000 fails jobs in redis.

The redis server fall because he doesn't have enough ram...

To try the limit just add this line in your initializer/sidekiq : Sidekiq::Failures::Config.max_failures_count = 10_000
