### PR TITLE
Added processor identity to failure data

### DIFF
--- a/lib/sidekiq/failures/middleware.rb
+++ b/lib/sidekiq/failures/middleware.rb
@@ -1,6 +1,7 @@
 module Sidekiq
   module Failures
     class Middleware
+      include Sidekiq::Util
       attr_accessor :msg
 
       def call(worker, msg, queue)
@@ -16,6 +17,7 @@ module Sidekiq
           :error => e.to_s,
           :backtrace => e.backtrace,
           :worker => msg['class'],
+          :processor => "#{hostname}:#{process_id}-#{Thread.current.object_id}:default",
           :queue => queue
         }
 

--- a/lib/sidekiq/failures/views/failures.slim
+++ b/lib/sidekiq/failures/views/failures.slim
@@ -23,6 +23,9 @@ header.row
           time datetime="#{Time.parse(msg['failed_at']).getutc.iso8601}"
             = msg['failed_at']
         td style="overflow: auto; padding: 10px;"
+          p
+            span Processor: 
+            strong = msg['processor']
           a.backtrace href="#" onclick="$(this).next().toggle(); return false"  = "#{msg['exception']}: #{msg['error']}"
           pre style="display: none; background: none; border: 0; width: 100%; max-height: 30em; font-size: 0.8em; white-space: nowrap;" == msg['backtrace'].join("<br />")
 


### PR DESCRIPTION
Now it is possible to track on which host job was failed
