### PR TITLE
we should still record a failure when retries disabled and mode is exhausted

### DIFF
--- a/lib/sidekiq/failures/middleware.rb
+++ b/lib/sidekiq/failures/middleware.rb
@@ -58,7 +58,7 @@ module Sidekiq
       end
 
       def last_try?
-        retry_count == max_retries - 1
+        ! msg['retry'] || retry_count == max_retries - 1
       end
 
       def retry_count


### PR DESCRIPTION
You can force failure recording with :all, but when you only disable retry for some jobs, you may still want :exhausted mode.
