### PR TITLE
catch all exceptions, not just those that inherit from StandardError

### DIFF
--- a/lib/sidekiq/failures/middleware.rb
+++ b/lib/sidekiq/failures/middleware.rb
@@ -10,7 +10,7 @@ module Sidekiq
         yield
       rescue Sidekiq::Shutdown
         raise
-      rescue => e
+      rescue Exception => e
         raise e if skip_failure?
 
         data = {

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -13,7 +13,7 @@ module Sidekiq
         Sidekiq.instance_eval { @failures_default_mode = nil }
       end
 
-      TestException = Class.new(StandardError)
+      TestException = Class.new(Exception)
       ShutdownException = Class.new(Sidekiq::Shutdown)
 
       class MockWorker


### PR DESCRIPTION
My workers were hitting exceptions that were not showing up in the Failures tab.  Turns out that the the middleware is only catching StandardError whereas these exceptions were subclasses of Exception.  I believe the Failures tab should catch all exception classes.
