### PR TITLE
Added a failed_queue_size call

### DIFF
--- a/lib/sidekiq/failures.rb
+++ b/lib/sidekiq/failures.rb
@@ -12,6 +12,10 @@ module Sidekiq
 
   SIDEKIQ_FAILURES_MODES = [:all, :exhausted, :off].freeze
 
+  module Failures
+    QUEUE_KEY = :failed
+  end
+
   # Sets the default failure tracking mode.
   #
   # The value provided here will be the default behavior but can be overwritten
@@ -49,7 +53,8 @@ module Sidekiq
     @failures_max_count
   end
 
-  module Failures
+  def self.failed_queue_size
+    Sidekiq.redis {|r| r.llen(Failures::QUEUE_KEY) }
   end
 end
 

--- a/lib/sidekiq/failures/middleware.rb
+++ b/lib/sidekiq/failures/middleware.rb
@@ -25,9 +25,9 @@ module Sidekiq
         }
 
         Sidekiq.redis do |conn|
-          conn.lpush(:failed, Sidekiq.dump_json(data))
+          conn.lpush(QUEUE_KEY, Sidekiq.dump_json(data))
           unless Sidekiq.failures_max_count == false
-            conn.ltrim(:failed, 0, Sidekiq.failures_max_count - 1)
+            conn.ltrim(QUEUE_KEY, 0, Sidekiq.failures_max_count - 1)
           end
         end
 

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -26,6 +26,23 @@ module Sidekiq
         end
       end
 
+      it 'returns the total number of failed jobs in the queue' do
+        msg = create_work('class' => MockWorker.to_s, 'args' => ['myarg'], 'failures' => true)
+
+        assert_equal 0, Sidekiq.failed_queue_size
+
+        actor = MiniTest::Mock.new
+        actor.expect(:processor_done, nil, [@processor])
+        actor.expect(:real_thread, nil, [nil, Celluloid::Thread])
+        @boss.expect(:async, actor, [])
+
+        assert_raises TestException do
+          @processor.process(msg)
+        end
+
+        assert_equal 1, Sidekiq.failed_queue_size
+      end
+
       it 'raises an error when failures_default_mode is configured incorrectly' do
         assert_raises ArgumentError do
           Sidekiq.failures_default_mode = 'exhaustion'
@@ -177,11 +194,11 @@ module Sidekiq
         assert_raises TestException do
           @processor.process(msg)
         end
- 
+
         assert_equal 1, failures_count
         assert_equal 1, $invokes
        end
- 
+
       it "records failure if retry disabled and configured to track exhaustion by default" do
         Sidekiq.failures_default_mode = 'exhausted'
 
@@ -233,7 +250,7 @@ module Sidekiq
         3.times do
           boss = MiniTest::Mock.new
           processor = ::Sidekiq::Processor.new(boss)
-          
+
           actor = MiniTest::Mock.new
           actor.expect(:processor_done, nil, [processor])
           actor.expect(:real_thread, nil, [nil, Celluloid::Thread])


### PR DESCRIPTION
Adds a consistent way of figuring out the total # of failed jobs in the queue. Example use case would be health checks. If there are >0 failed jobs in the queue since.
