### PR TITLE
Added a checkbox for single/bulk retrying of jobs

### DIFF
--- a/lib/sidekiq/failures/views/failures.erb
+++ b/lib/sidekiq/failures/views/failures.erb
@@ -10,40 +10,51 @@
 </header>
 
 <% if @messages.size > 0 %>
-  <table class="table table-striped table-bordered table-white" style="width: 100%; margin: 0; table-layout:fixed;">
-    <thead>
-      <th style="width: 25%">Worker, Args</th>
-      <th style="width: 10%">Queue</th>
-      <th style="width: 15%">Failed At</th>
-      <th style="width: 50%">Exception</th>
-    </thead>
-    <% @messages.each do |msg| %>
-      <tr>
-        <td style="overflow: hidden; text-overflow: ellipsis;">
-          <%= msg['worker'] %>
-          <br />
-          <%= msg['payload']['args'].inspect[0..100] %>
-        </td>
-        <td><%= msg['queue'] %></td>
-        <td>
-          <time datetime="<%= "#{Time.parse(msg['failed_at']).getutc.iso8601}" %>">
-            <%= msg['failed_at'] %>
-          </time>
-        </td>
-        <td style="overflow: auto; padding: 10px;">
-          <a class="backtrace" href="#" onclick="$(this).next().toggle(); return false">
-            <%= msg['exception'] %>: <%= msg['error'] %>
-          </a>
-          <pre style="display: none; background: none; border: 0; width: 100%; max-height: 30em; font-size: 0.8em; white-space: nowrap;">
-            <%= msg['backtrace'].join("<br />") %>
-          </pre>
-          <p>
-            <span>Processor: <%= msg['processor'] %></span>
-          </p>
-        </td>
-      </tr>
-    <% end %>
-  </table>
+  <form action="<%= root_path %>failures/retries" method="post">
+    <table class="table table-striped table-bordered table-white" style="width: 100%; margin: 0; table-layout:fixed;">
+      <thead>
+        <th width="30px" style="text-align: center;">
+          <input type="checkbox" class="check_all" />
+        </th>
+        <th style="width: 25%">Worker, Args</th>
+        <th style="width: 10%">Queue</th>
+        <th style="width: 15%">Failed At</th>
+        <th style="width: 50%">Exception</th>
+      </thead>
+      <% @messages.each_index do |i| %>
+        <% msg = @messages[i] %>
+        <tr>
+          <td style="text-align: center;">
+            <input type='checkbox' name='ids[]' value='<%= i %>' />
+          </td>
+          <td style="overflow: hidden; text-overflow: ellipsis;">
+            <%= msg['worker'] %>
+            <br />
+            <%= msg['payload']['args'].inspect[0..100] %>
+          </td>
+          <td><%= msg['queue'] %></td>
+          <td>
+            <time datetime="<%= "#{Time.parse(msg['failed_at']).getutc.iso8601}" %>">
+              <%= msg['failed_at'] %>
+            </time>
+          </td>
+          <td style="overflow: auto; padding: 10px;">
+            <a class="backtrace" href="#" onclick="$(this).next().toggle(); return false">
+              <%= msg['exception'] %>: <%= msg['error'] %>
+            </a>
+            <pre style="display: none; background: none; border: 0; width: 100%; max-height: 30em; font-size: 0.8em; white-space: nowrap;">
+              <%= msg['backtrace'].join("<br />") %>
+            </pre>
+            <p>
+              <span>Processor: <%= msg['processor'] %></span>
+            </p>
+          </td>
+        </tr>
+      <% end %>
+    </table>
+    <input class="btn btn-primary btn-xs" type="submit" name="retry" style="margin-top: 8px;" value="<%= t('RetryNow') %>" />
+   </form>
+
   <div class="row">
     <div class="span5">
       <form class="form-inline" action="<%= "#{root_path}failures/remove" %>" method="post" style="margin: 20px 0">


### PR DESCRIPTION
Adds a simple checkbox on the far left of the failed table allowing retrying of selected jobs in Sidekiq. The failure UI is nice, but not being able to retry failed jobs is one thing we miss after moving to Sidekiq.
