### PR TITLE
Fix private method call `retry_attempts_from`

### DIFF
--- a/lib/sidekiq/failures/middleware.rb
+++ b/lib/sidekiq/failures/middleware.rb
@@ -66,11 +66,7 @@ module Sidekiq
       end
 
       def max_retries
-        if msg['retry'].is_a?(Fixnum)
-          msg['retry']
-        else
-          default_max_retries
-        end
+        retry_middleware.send(:retry_attempts_from, msg['retry'], default_max_retries)
       end
 
       def retry_middleware


### PR DESCRIPTION
In recent update of mperham/sidekiq@a42e4960c14d9bdca22747f9c51a8c0617762215,  `retry_attempts_from` became a private method which result in error raised in `sidekiq-failures` middleware.
