### PR TITLE
RetryJobs#retry_attempts_from is presently a private method

### DIFF
--- a/lib/sidekiq/failures/middleware.rb
+++ b/lib/sidekiq/failures/middleware.rb
@@ -66,7 +66,11 @@ module Sidekiq
       end
 
       def max_retries
-        retry_middleware.retry_attempts_from(msg['retry'], default_max_retries)
+        if msg['retry'].is_a?(Fixnum)
+          msg['retry']
+        else
+          default_max_retries
+        end
       end
 
       def retry_middleware


### PR DESCRIPTION
Pasted from error in sidekiq:

`private method `retry_attempts_from' called for #<Sidekiq::Middleware::Server::RetryJobs:0x0000000761ccc0>`

As of [this](https://github.com/mperham/sidekiq/commit/a42e4960c14d9bdca22747f9c51a8c0617762215#diff-e0641eb66d77ea31a898bffe0a375076) commit, retry_attempts_from is a private method. I've (roughly) duplicated it's behavior here.
