### PR TITLE
Add Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+services:
+  - redis-server
+rvm:
+  - 1.9.3
+  - jruby-19mode
+  - 2.0.0


### PR DESCRIPTION
Due to recent changes, `redis-server` wouldn't get started unless explicitly specified in `.travis.yml`.
This pull request should fix recent test failures.

I also enabled testing for multiple Ruby versions in this pull request:
- MRI 2.0
- MRI 1.9.3
- JRuby 1.9mode
