### PR TITLE
Expandable arguments for web UI

### DIFF
--- a/lib/sidekiq/failures/views/failures.erb
+++ b/lib/sidekiq/failures/views/failures.erb
@@ -22,7 +22,18 @@
         <td style="overflow: hidden; text-overflow: ellipsis;">
           <%= msg['worker'] %>
           <br />
-          <%= msg['payload']['args'].inspect[0..100] %>
+
+          <% args = msg['payload']['args'].inspect %>
+          <% if args.length > 100 %>
+          <a class="args" href="#" onclick="$(this).next().toggle(); return false">
+            <%= args[0..100] %>...
+          </a>
+          <pre style="display: none; background: none; border: 0; width: 100%; font-size: 0.8em;">
+            <%= args %>
+          </pre>
+          <% else %>
+            <%= args %>
+          <% end %>
         </td>
         <td><%= msg['queue'] %></td>
         <td>


### PR DESCRIPTION
Adds possibility to expand arguments on web UI to see full value on click.

Few screenshots to illustrate how it looks:
1. current master:
   
   ![2013-12-28 23 50 58](https://f.cloud.github.com/assets/789247/1818449/18aaf146-7005-11e3-8145-0e4afd78aef2.png)
2. with expandable arguments - collapsed (by default):
   
   ![2013-12-29 00 08 19](https://f.cloud.github.com/assets/789247/1818452/3a158f4e-7005-11e3-8ce8-227953710714.png)
3. with expandable arguments - expanded (after click):
   
   ![2013-12-29 00 08 37](https://f.cloud.github.com/assets/789247/1818453/4bb0e474-7005-11e3-882d-6ebe67ac65ce.png)
