### PR TITLE
escape arguments for task

### DIFF
--- a/lib/sidekiq/failures/views/failures.erb
+++ b/lib/sidekiq/failures/views/failures.erb
@@ -22,7 +22,7 @@
         <td style="overflow: hidden; text-overflow: ellipsis;">
           <%= msg['worker'] %>
           <br />
-          <%= msg['payload']['args'].inspect[0..100] %>
+          <%= h(msg['payload']['args'].inspect[0..100]) %>
         </td>
         <td><%= msg['queue'] %></td>
         <td>


### PR DESCRIPTION
erb in the sidekiq web interface is not autoescaping strings.
the payload args can contain arbitrary user input such as html which can break the layout.
