### PR TITLE
Remove the Sidekiq::Util dependency / Sidekiq 3.0.x compatibility

### DIFF
--- a/lib/sidekiq/failures/middleware.rb
+++ b/lib/sidekiq/failures/middleware.rb
@@ -2,7 +2,6 @@ module Sidekiq
   module Failures
 
     class Middleware
-      include Sidekiq::Util
       attr_accessor :msg
 
       def call(worker, msg, queue)
@@ -20,7 +19,7 @@ module Sidekiq
           :error => e.message,
           :backtrace => e.backtrace,
           :worker => msg['class'],
-          :processor => "#{hostname}:#{process_id}-#{Thread.current.object_id}",
+          :processor => identity,
           :queue => queue
         }
 
@@ -75,6 +74,14 @@ module Sidekiq
 
       def default_max_retries
         Sidekiq::Middleware::Server::RetryJobs::DEFAULT_MAX_RETRY_ATTEMPTS
+      end
+
+      def hostname
+        Socket.gethostname
+      end
+
+      def identity
+        @@identity ||= "#{hostname}:#{$$}"
       end
     end
   end


### PR DESCRIPTION
Sidekiq::Util is not intended for use by middleware.  Using it in middleware breaks in Sidekiq 3.0.  This PR addresses this issue by removing the dependency and implementing the required methods.

This restores compatibility with Sidekiq 3.0 (at least in specs) and maintains backwards compatibility with Sidekiq 2.14.0+, at the cost of a slight change in how the processor is displayed.  It may be desirable to restore the thread object id to the processor identifier.
