### PR TITLE
Failure improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.4.1
   * Restore compatibility for failed payloads created with 0.3.0
+  * Ability to reset failed counter anyway, there are Failed jobs or not. (@davetoxa)
+  * Fix sidekiq failures counter (@davetoxa)
 
 ## 0.4.0
   * Bump sidekiq dependency to sidekiq >= 2.16.0

--- a/lib/sidekiq/failures.rb
+++ b/lib/sidekiq/failures.rb
@@ -60,7 +60,7 @@ module Sidekiq
     end
 
     def self.count
-      Sidekiq.redis {|r| r.zcard(LIST_KEY) }
+      Sidekiq::Stats.new.failed
     end
   end
 end

--- a/lib/sidekiq/failures/views/failures.erb
+++ b/lib/sidekiq/failures/views/failures.erb
@@ -60,9 +60,6 @@
     <input class="btn btn-danger btn-xs pull-left" type="submit" name="delete" value="<%= t('Delete') %>" />
   </form>
 
-  <form action="<%= root_path %>failures/all/reset" method="post">
-    <input class="btn btn-danger btn-xs pull-right" type="submit" name="reset" value="<%= t('Reset Counter') %>" data-confirm="<%= t('AreYouSure') %>" />
-  </form>
   <form action="<%= root_path %>failures/all/delete" method="post">
     <input class="btn btn-danger btn-xs pull-right" type="submit" name="delete" value="<%= t('DeleteAll') %>" data-confirm="<%= t('AreYouSure') %>" />
   </form>
@@ -73,3 +70,7 @@
 <% else %>
   <div class="alert alert-success"><%= t('NoFailedJobsFound') %></div>
 <% end %>
+
+<form action="<%= root_path %>failures/all/reset" method="post">
+  <input class="btn btn-danger btn-xs pull-right" type="submit" name="reset" value="<%= t('Reset Counter') %>" data-confirm="<%= t('AreYouSure') %>" />
+</form>


### PR DESCRIPTION
When I delete all jobs via button, I realized that jobs were dropped, 
but I have " a Failed count"  >  0 and no way to reset this counter.

I opened the console, and try to got this number via sidekiq-failures api 

``` ruby
Sidekiq::RedisConnection.create.with{|a| a.zcard(:failed)}
2014-05-05T21:48:50Z 10350 TID-znnu9k INFO: Sidekiq client with redis options {}
=> 0
```

Then, I opened the sidekiq api, I got another way to get this number 

``` ruby
 Sidekiq::Stats.new.failed
```

This is the right counter.

So I had replaced counter and move button from @failures.size condition, to reset counter anyway, there are Failed jobs or not.
