### PR TITLE
Add paging to bottom of the view

### DIFF
--- a/lib/sidekiq/failures/views/failures.erb
+++ b/lib/sidekiq/failures/views/failures.erb
@@ -70,6 +70,12 @@
     <input class="btn btn-danger btn-xs pull-right" type="submit" name="retry" value="<%= t('RetryAll') %>" data-confirm="<%= t('AreYouSure') %>" />
   </form>
 
+  <% if @failures.size > 0 && @total_size > @count %>
+    <div class="col-sm-4">
+      <%= erb :_paging, :locals => { :url => "#{root_path}failures" } %>
+    </div>
+  <% end %>
+
 <% else %>
   <div class="alert alert-success"><%= t('NoFailedJobsFound') %></div>
 <% end %>


### PR DESCRIPTION
This was helpful when there is a page (or multiple pages) of failures so that you can change pages without having to scroll up to the top of the page.
