### PR TITLE
Add overflow to fix the #94

### DIFF
--- a/lib/sidekiq/failures/views/failures.erb
+++ b/lib/sidekiq/failures/views/failures.erb
@@ -46,7 +46,7 @@
             <a class="backtrace" href="#" onclick="$(this).next().toggle(); return false">
               <%= h entry['error_class'] %>: <%= h entry['error_message'] %>
             </a>
-            <pre style="display: none; background: none; border: 0; width: 100%; max-height: 30em; font-size: 0.8em; white-space: nowrap;">
+            <pre style="display: none; background: none; border: 0; width: 100%; max-height: 30em; font-size: 0.8em; white-space: nowrap; overflow: auto;">
               <%= entry['error_backtrace'].join("<br />") if entry['error_backtrace'] %>
             </pre>
             <p>


### PR DESCRIPTION
I added an overflow to fix the overlap of elements. With it I believe that you can close the #94.

![sideki-failures fixed](https://dl.dropboxusercontent.com/u/1540761/screen/sidekiq-failures-fixed.png)