### PR TITLE
limit error message to 500 symbols

### DIFF
--- a/lib/sidekiq/failures/views/failures.erb
+++ b/lib/sidekiq/failures/views/failures.erb
@@ -44,7 +44,7 @@
           <td><%= safe_relative_time(entry['failed_at']) %></td>
           <td style="overflow: auto; padding: 10px;">
             <a class="backtrace" href="#" onclick="$(this).next().toggle(); return false">
-              <%= h entry['error_class'] %>: <%= h entry['error_message'] %>
+              <%= h entry['error_class'] %>: <%= h entry['error_message'].size > 500 ? entry['error_message'][0..500] + '...' : entry['error_message'] %>
             </a>
             <pre style="display: none; background: none; border: 0; width: 100%; max-height: 30em; font-size: 0.8em; white-space: nowrap; overflow: auto;">
               <%= entry['error_backtrace'].join("<br />") if entry['error_backtrace'] %>


### PR DESCRIPTION
I had an issue with queries with lots of params, they are too looooong, may be someone else have similar problems.