### PR TITLE
Improve the web interface

### DIFF
--- a/lib/sidekiq/failures/views/failures.erb
+++ b/lib/sidekiq/failures/views/failures.erb
@@ -21,11 +21,11 @@
               <input type="checkbox" class="check_all" />
             </label>
           </th>
-          <th style="width: 10%"><%= t('FailedAt') %></th>
-          <th style="width: 10%"><%= t('Queue') %></th>
-          <th style="width: 20%"><%= t('Worker') %></th>
-          <th style="width: 10%"><%= t('Arguments') %></th>
-          <th style="width: 50%"><%= t('Error') %></th>
+          <th><%= t('FailedAt') %></th>
+          <th><%= t('Queue') %></th>
+          <th><%= t('Worker') %></th>
+          <th><%= t('Arguments') %></th>
+          <th><%= t('Error') %></th>
         </tr>
       </thead>
       <% @failures.each do |entry| %>

--- a/lib/sidekiq/failures/views/failures.erb
+++ b/lib/sidekiq/failures/views/failures.erb
@@ -21,10 +21,10 @@
               <input type="checkbox" class="check_all" />
             </label>
           </th>
+          <th style="width: 10%"><%= t('FailedAt') %></th>
+          <th style="width: 10%"><%= t('Queue') %></th>
           <th style="width: 20%"><%= t('Worker') %></th>
           <th style="width: 10%"><%= t('Arguments') %></th>
-          <th style="width: 10%"><%= t('Queue') %></th>
-          <th style="width: 10%"><%= t('FailedAt') %></th>
           <th style="width: 50%"><%= t('Error') %></th>
         </tr>
       </thead>
@@ -35,14 +35,14 @@
               <input type='checkbox' name='key[]' value='<%= job_params(entry.item, entry.score) %>' />
             </label>
           </td>
-          <td><a href="<%= root_path %>failures/<%= job_params(entry.item, entry.score) %>"><%= entry.klass %></a></td>
-          <td>
-            <div class="args"><%= display_args(entry.args) %></div>
-          </td>
+          <td><a href="<%= root_path %>failures/<%= job_params(entry.item, entry.score) %>"><%= safe_relative_time(entry['failed_at']) %></a></td>
           <td>
             <a href="<%= root_path %>queues/<%= entry.queue %>"><%= entry.queue %></a>
           </td>
-          <td><%= safe_relative_time(entry['failed_at']) %></td>
+          <td><%= entry.klass %></td>
+          <td>
+            <div class="args"><%= display_args(entry.args) %></div>
+          </td>
           <td style="overflow: auto; padding: 10px;">
             <a class="backtrace" href="#" onclick="$(this).next().toggle(); return false">
               <%= h entry['error_class'] %>: <%= h entry['error_message'].size > 500 ? entry['error_message'][0..500] + '...' : entry['error_message'] %>

--- a/lib/sidekiq/failures/web_extension.rb
+++ b/lib/sidekiq/failures/web_extension.rb
@@ -78,6 +78,17 @@ module Sidekiq
           FailureSet.new.retry_all_failures
           redirect "#{root_path}failures"
         end
+
+        app.get '/filter/failures' do
+          redirect "#{root_path}failures"
+        end
+
+        app.post '/filter/failures' do
+          @failures = Sidekiq::Failures::FailureSet.new.scan("*#{params[:substr]}*")
+          @current_page = 1
+          @count = @total_size = @failures.size
+          render(:erb, File.read(File.join(view_path, "failures.erb")))
+        end
       end
     end
   end

--- a/lib/sidekiq/failures/web_extension.rb
+++ b/lib/sidekiq/failures/web_extension.rb
@@ -19,7 +19,7 @@ module Sidekiq
 
         app.get "/failures" do
           @count = (params[:count] || 25).to_i
-          (@current_page, @total_size, @failures) = page(LIST_KEY, params[:page], @count)
+          (@current_page, @total_size, @failures) = page(LIST_KEY, params[:page], @count, :reverse => true)
           @failures = @failures.map {|msg, score| Sidekiq::SortedEntry.new(nil, score, msg) }
 
           render(:erb, File.read(File.join(view_path, "failures.erb")))

--- a/test/web_extension_test.rb
+++ b/test/web_extension_test.rb
@@ -176,6 +176,15 @@ module Sidekiq
         last_response.status.must_equal 302
         last_response.location.must_match /failures/
       end
+
+      if defined? Sidekiq::Pro
+        it 'can filter failure' do
+          create_sample_failure
+          post '/filter/failures', substr: 'new'
+
+          last_response.status.must_equal 200
+        end
+      end
     end
 
     describe 'when there is specific failure' do


### PR DESCRIPTION
I think the Failures page of `sidekiq-failtures` should act like Retires / Scheduled page of `sidekiq`, which means they should have the same order of the columns (time, queue, class, arguments), and newest first.
This PR also provide the route for `sidekiq-pro` [UI Filtering](https://github.com/mperham/sidekiq/wiki/UI-Filtering)