### PR TITLE
[WIP] Sidekiq 5.0.0 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,5 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in sidekiq-failures.gemspec
 gemspec
 
+gem 'minitest', '~> 5.0.0'
 gem 'sidekiq', ENV['SIDEKIQ_VERSION'] if ENV['SIDEKIQ_VERSION']

--- a/lib/sidekiq/failures.rb
+++ b/lib/sidekiq/failures.rb
@@ -67,8 +67,19 @@ end
 
 Sidekiq.configure_server do |config|
   config.server_middleware do |chain|
-    chain.insert_before Sidekiq::Middleware::Server::RetryJobs,
-                        Sidekiq::Failures::Middleware
+    # Supports Ruby 1.9 +
+    # Sidekiq 5.0.0 removes `Sidekiq::Middleware::Server::RetryJobs` so we simple add
+    # the Sidekiq::Failures::Middleware in top of stack
+    if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('5.0.0')
+      Sidekiq.configure_server do |config|
+        config.server_middleware do |chain|
+          chain.add Sidekiq::Failures::Middleware
+        end
+      end
+    else
+      chain.insert_before Sidekiq::Middleware::Server::RetryJobs,
+                          Sidekiq::Failures::Middleware
+    end
   end
 end
 

--- a/lib/sidekiq/failures/version.rb
+++ b/lib/sidekiq/failures/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Failures
-    VERSION = "0.4.5"
+    VERSION = "0.4.6"
   end
 end

--- a/sidekiq-failures.gemspec
+++ b/sidekiq-failures.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "sidekiq", ">= 2.16.0"
 
+  gem.add_dependency 'redis-namespace'
+  gem.add_development_dependency 'celluloid'
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rack-test"
   gem.add_development_dependency "sprockets"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,8 @@ require "minitest/mock"
 
 require "rack/test"
 
+$CELLULOID_DEBUG = true
+
 require "celluloid"
 require "sidekiq"
 require "sidekiq-failures"


### PR DESCRIPTION
I'm trying to make this project work with Sidekiq 5.0.0 released in April/2017...

Tests are not passing and there's a lot of Celluloid stuff and Sidekiq [dropped Celluloid](https://github.com/mperham/sidekiq/blob/master/4.0-Upgrade.md) dependency in version 4.0...

I will work in this PR to make it more closer to being compatible with version 4.0.0 too, and maybe with older versions...but I don't now if this will be possible or really desired.

@mhfs Do you have some advice or something like this? I don't know Sidekiq internal behavior very well so I need to study it first.
 