### PR TITLE
Compatibility update for sidekiq 4.0+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,21 @@
 language: ruby
+sudo: false
+cache: bundler
 services:
   - redis-server
+before_install:
+  - gem install bundler
+  - gem update bundler
 rvm:
-  - 1.9.3
-  - jruby-19mode
-  - 2.0.0
-  - 2.1
+  - jruby-9.1.6.0
+  - 2.2.4
+  - 2.3.0
+  - 2.4.0
 env:
   matrix:
-    - SIDEKIQ_VERSION="~> 2.16"
-    - SIDEKIQ_VERSION="~> 2.17"
-    - SIDEKIQ_VERSION="~> 3.0"
-    - SIDEKIQ_VERSION="~> 3.1"
+    - SIDEKIQ_VERSION="~> 4.0"
+    - SIDEKIQ_VERSION="~> 4.2"
+    - SIDEKIQ_VERSION="~> 5.0"
 matrix:
   allow_failures:
-    - rvm: 1.9.3
-    - rvm: jruby-19mode
+    - rvm: jruby-9.1.6.0 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Sidekiq::Failures.reset_failures
 
 ## Dependencies
 
-Depends on Sidekiq >= 2.16.0
+Depends on Sidekiq >= 4.0.0
 
 ## Contributing
 

--- a/lib/sidekiq/failures.rb
+++ b/lib/sidekiq/failures.rb
@@ -47,9 +47,11 @@ module Sidekiq
 
   # Fetches the failures max count value
   def self.failures_max_count
-    return 1000 if @failures_max_count.nil?
-
-    @failures_max_count
+    if !instance_variable_defined?(:@failures_max_count) || @failures_max_count.nil?
+      1000
+    else
+      @failures_max_count
+    end
   end
 
   module Failures

--- a/lib/sidekiq/failures.rb
+++ b/lib/sidekiq/failures.rb
@@ -12,6 +12,10 @@ require "sidekiq/failures/failure_set"
 require "sidekiq/failures/middleware"
 require "sidekiq/failures/web_extension"
 
+if Sidekiq::VERSION < '5'
+  require "sidekiq/middleware/server/retry_jobs"
+end
+
 module Sidekiq
 
   SIDEKIQ_FAILURES_MODES = [:all, :exhausted, :off].freeze

--- a/lib/sidekiq/failures.rb
+++ b/lib/sidekiq/failures.rb
@@ -5,6 +5,7 @@ rescue LoadError
 end
 
 require "sidekiq/api"
+require "sidekiq/version"
 require "sidekiq/failures/version"
 require "sidekiq/failures/sorted_entry"
 require "sidekiq/failures/failure_set"

--- a/lib/sidekiq/failures/middleware.rb
+++ b/lib/sidekiq/failures/middleware.rb
@@ -79,12 +79,21 @@ module Sidekiq
         retry_middleware.send(:retry_attempts_from, msg['retry'], default_max_retries)
       end
 
+      def retry_middleware_class
+        if Sidekiq::VERSION < '5'
+          Sidekiq::Middleware::Server::RetryJobs
+        else
+          Sidekiq::JobRetry
+        end
+      end
+
       def retry_middleware
-        @retry_middleware ||= Sidekiq::Middleware::Server::RetryJobs.new
+        @retry_middleware ||=
+          retry_middleware_class.new
       end
 
       def default_max_retries
-        Sidekiq::Middleware::Server::RetryJobs::DEFAULT_MAX_RETRY_ATTEMPTS
+        retry_middleware_class::DEFAULT_MAX_RETRY_ATTEMPTS
       end
 
       def hostname

--- a/lib/sidekiq/failures/middleware.rb
+++ b/lib/sidekiq/failures/middleware.rb
@@ -79,21 +79,13 @@ module Sidekiq
         retry_middleware.send(:retry_attempts_from, msg['retry'], default_max_retries)
       end
 
-      def retry_middleware_class
-        if Sidekiq::VERSION < '5'
-          Sidekiq::Middleware::Server::RetryJobs
-        else
-          Sidekiq::JobRetry
-        end
-      end
-
       def retry_middleware
         @retry_middleware ||=
-          retry_middleware_class.new
+          Sidekiq::Failures.retry_middleware_class.new
       end
 
       def default_max_retries
-        retry_middleware_class::DEFAULT_MAX_RETRY_ATTEMPTS
+        Sidekiq::Failures.retry_middleware_class::DEFAULT_MAX_RETRY_ATTEMPTS
       end
 
       def hostname

--- a/sidekiq-failures.gemspec
+++ b/sidekiq-failures.gemspec
@@ -15,8 +15,9 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Sidekiq::Failures::VERSION
 
-  gem.add_dependency "sidekiq", ">= 2.16.0"
+  gem.add_dependency "sidekiq", ">= 4.0.0"
 
+  gem.add_development_dependency "minitest"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rack-test"
   gem.add_development_dependency "sprockets"

--- a/test/failures_test.rb
+++ b/test/failures_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+module Sidekiq
+  describe Failures do
+    describe '.retry_middleware_class' do
+      it 'returns based on Sidekiq::VERISON' do
+        case Sidekiq::VERSION[0]
+        when '5'
+          assert_equal Failures.retry_middleware_class, Sidekiq::JobRetry
+        when '4'
+          assert_equal Failures.retry_middleware_class, Sidekiq::Middleware::Server::RetryJobs
+        end
+      end
+    end
+  end
+end

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -4,9 +4,9 @@ module Sidekiq
   module Failures
     describe "Middleware" do
       before do
-        Celluloid.boot
         $invokes = 0
         @boss = MiniTest::Mock.new
+        2.times { @boss.expect(:options, {:queues => ['default'] }, []) }
         @processor = ::Sidekiq::Processor.new(@boss)
         Sidekiq.server_middleware {|chain| chain.add Sidekiq::Failures::Middleware }
         Sidekiq.redis = REDIS
@@ -44,7 +44,7 @@ module Sidekiq
 
         actor = MiniTest::Mock.new
         actor.expect(:processor_done, nil, [@processor])
-        actor.expect(:real_thread, nil, [nil, Celluloid::Thread])
+        actor.expect(:real_thread, nil, [nil, nil])
         2.times { @boss.expect(:async, actor, []) }
 
         assert_raises TestException do
@@ -62,7 +62,7 @@ module Sidekiq
 
         actor = MiniTest::Mock.new
         actor.expect(:processor_done, nil, [@processor])
-        actor.expect(:real_thread, nil, [nil, Celluloid::Thread])
+        actor.expect(:real_thread, nil, [nil, nil])
         2.times { @boss.expect(:async, actor, []) }
 
         assert_raises TestException do
@@ -80,8 +80,7 @@ module Sidekiq
 
         actor = MiniTest::Mock.new
         actor.expect(:processor_done, nil, [@processor])
-        actor.expect(:real_thread, nil, [nil, Celluloid::Thread])
-        2.times { @boss.expect(:async, actor, []) }
+        actor.expect(:real_thread, nil, [nil, nil])
 
         @processor.process(msg)
         @boss.verify
@@ -97,7 +96,7 @@ module Sidekiq
 
         actor = MiniTest::Mock.new
         actor.expect(:processor_done, nil, [@processor])
-        actor.expect(:real_thread, nil, [nil, Celluloid::Thread])
+        actor.expect(:real_thread, nil, [nil, nil])
         2.times { @boss.expect(:async, actor, []) }
 
         assert_raises TestException do
@@ -117,7 +116,7 @@ module Sidekiq
 
         actor = MiniTest::Mock.new
         actor.expect(:processor_done, nil, [@processor])
-        actor.expect(:real_thread, nil, [nil, Celluloid::Thread])
+        actor.expect(:real_thread, nil, [nil, nil])
         2.times { @boss.expect(:async, actor, []) }
 
         assert_raises TestException do
@@ -136,7 +135,7 @@ module Sidekiq
 
         actor = MiniTest::Mock.new
         actor.expect(:processor_done, nil, [@processor])
-        actor.expect(:real_thread, nil, [nil, Celluloid::Thread])
+        actor.expect(:real_thread, nil, [nil, nil])
         2.times { @boss.expect(:async, actor, []) }
 
         assert_raises TestException do
@@ -154,7 +153,7 @@ module Sidekiq
 
         actor = MiniTest::Mock.new
         actor.expect(:processor_done, nil, [@processor])
-        actor.expect(:real_thread, nil, [nil, Celluloid::Thread])
+        actor.expect(:real_thread, nil, [nil, nil])
         2.times { @boss.expect(:async, actor, []) }
 
         assert_raises TestException do
@@ -172,7 +171,7 @@ module Sidekiq
 
         actor = MiniTest::Mock.new
         actor.expect(:processor_done, nil, [@processor])
-        actor.expect(:real_thread, nil, [nil, Celluloid::Thread])
+        actor.expect(:real_thread, nil, [nil, nil])
         2.times { @boss.expect(:async, actor, []) }
 
         assert_raises TestException do
@@ -192,7 +191,7 @@ module Sidekiq
 
         actor = MiniTest::Mock.new
         actor.expect(:processor_done, nil, [@processor])
-        actor.expect(:real_thread, nil, [nil, Celluloid::Thread])
+        actor.expect(:real_thread, nil, [nil, nil])
         2.times { @boss.expect(:async, actor, []) }
 
         assert_raises TestException do
@@ -212,7 +211,7 @@ module Sidekiq
 
         actor = MiniTest::Mock.new
         actor.expect(:processor_done, nil, [@processor])
-        actor.expect(:real_thread, nil, [nil, Celluloid::Thread])
+        actor.expect(:real_thread, nil, [nil, nil])
         2.times { @boss.expect(:async, actor, []) }
 
         assert_raises TestException do
@@ -233,11 +232,12 @@ module Sidekiq
 
         3.times do
           boss = MiniTest::Mock.new
+          2.times { boss.expect(:options, {:queues => ['default'] }, []) }
           processor = ::Sidekiq::Processor.new(boss)
 
           actor = MiniTest::Mock.new
           actor.expect(:processor_done, nil, [processor])
-          actor.expect(:real_thread, nil, [nil, Celluloid::Thread])
+          actor.expect(:real_thread, nil, [nil, nil])
           2.times { boss.expect(:async, actor, []) }
 
           assert_raises TestException do
@@ -261,7 +261,7 @@ module Sidekiq
 
         actor = MiniTest::Mock.new
         actor.expect(:processor_done, nil, [@processor])
-        actor.expect(:real_thread, nil, [nil, Celluloid::Thread])
+        actor.expect(:real_thread, nil, [nil, nil])
         @boss.expect(:async, actor, [])
 
         assert_raises TestException do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,4 @@
-Encoding.default_external = Encoding::UTF_8
-Encoding.default_internal = Encoding::UTF_8
+$TESTING = true
 
 require "minitest/autorun"
 require "minitest/spec"
@@ -7,14 +6,12 @@ require "minitest/mock"
 
 require "rack/test"
 
-require "celluloid"
 require "sidekiq"
 require "sidekiq-failures"
 require "sidekiq/processor"
 require "sidekiq/fetch"
 require "sidekiq/cli"
 
-Celluloid.logger = nil
 Sidekiq.logger.level = Logger::ERROR
 
-REDIS = Sidekiq::RedisConnection.create(:url => "redis://localhost/15", :namespace => 'sidekiq_failures_test')
+REDIS = Sidekiq::RedisConnection.create(url: "redis://localhost/15")

--- a/test/web_extension_test.rb
+++ b/test/web_extension_test.rb
@@ -5,17 +5,15 @@ module Sidekiq
   describe "WebExtension" do
     include Rack::Test::Methods
 
+    TOKEN = rand(2**128-1).freeze
+
     def app
       Sidekiq::Web
     end
 
-    def token
-      @token ||= Rack::Protection::AuthenticityToken.random_token
-    end
-
     before do
-      env 'rack.session', { csrf: token }
-      env 'HTTP_X_CSRF_TOKEN', token
+      env 'rack.session', { csrf: TOKEN }
+      env 'HTTP_X_CSRF_TOKEN', TOKEN
       Sidekiq.redis = REDIS
       Sidekiq.redis {|c| c.flushdb }
     end


### PR DESCRIPTION
Update dependencies, middleware, and spec coverage to run successfully against sidekiq 4.0 and higher