### PR TITLE
Adding license to gemspec.

### DIFF
--- a/sidekiq-failures.gemspec
+++ b/sidekiq-failures.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q{Keep track of Sidekiq failed jobs}
   gem.summary       = %q{Keeps track of Sidekiq failed jobs and adds a tab to the Web UI to let you browse them. Makes use of Sidekiq's custom tabs and middleware chain.}
   gem.homepage      = "https://github.com/mhfs/sidekiq-failures/"
+  gem.license       = "MIT"
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the gemspec it becomes available through the public RubyGems API and that way other tools like VersionEye can fetch it easier.