### PR TITLE
escape error class and error message on failure show page

### DIFF
--- a/lib/sidekiq/failures/views/failure.erb
+++ b/lib/sidekiq/failures/views/failure.erb
@@ -6,12 +6,12 @@
     <tr>
       <th><%= t('ErrorClass') %></th>
       <td>
-        <code><%= @failure['error_class'] %></code>
+        <code><%= h @failure['error_class'] %></code>
       </td>
     </tr>
     <tr>
       <th><%= t('ErrorMessage') %></th>
-      <td><%= @failure['error_message'] %></td>
+      <td><%= h @failure['error_message'] %></td>
     </tr>
     <% if !@failure['error_backtrace'].nil? %>
       <tr>

--- a/test/web_extension_test.rb
+++ b/test/web_extension_test.rb
@@ -193,18 +193,35 @@ module Sidekiq
 
     describe 'when there is specific failure' do
       describe 'with unescaped data' do
-        before do
-          create_sample_failure(args: ['<h1>omg</h1>'], error_message: '<p>wow</p>')
-          get '/failures'
-        end
+          before do
+            create_sample_failure(args: ['<h1>omg</h1>'], error_message: '<p>wow</p>')
+          end
 
-        it 'can escape arguments' do
-          last_response.body.must_match(/&quot;&lt;h1&gt;omg&lt;&#x2F;h1&gt;&quot;/)
-        end
+          describe 'failures index' do
+            before do
+              get '/failures'
+            end
+            it 'can escape arguments' do
+              last_response.body.must_match(/&quot;&lt;h1&gt;omg&lt;&#x2F;h1&gt;&quot;/)
+            end
 
-        it 'can escape error message' do
-          last_response.body.must_match(/ArgumentError: &lt;p&gt;wow&lt;&#x2F;p&gt;/)
-        end
+            it 'can escape error message' do
+              last_response.body.must_match(/ArgumentError: &lt;p&gt;wow&lt;&#x2F;p&gt;/)
+            end
+          end
+
+          describe 'failures show' do
+            before do
+              get "/failures/#{failure_score}"
+            end
+            it 'can escape arguments' do
+              last_response.body.must_match(/&lt;p&gt;wow&lt;&#x2F;p&gt;/)
+            end
+
+            it 'can escape error message' do
+              last_response.body.must_match(/ArgumentError/)
+            end
+          end
       end
 
       describe 'with deprecated payload' do


### PR DESCRIPTION
they are already escaped on failures index

before 

![screen shot 2017-09-20 at 4 51 35 pm](https://user-images.githubusercontent.com/3374461/30668933-6ca3ae94-9e2a-11e7-8de7-b3edd7e2c1a0.png)

after 

![screen shot 2017-09-20 at 4 51 18 pm](https://user-images.githubusercontent.com/3374461/30668923-65bcd11e-9e2a-11e7-8c5d-c37bbdf349ab.png)
