### PR TITLE
Add 1 to retry_count To Properly Report Exhausted Failures 

### DIFF
--- a/lib/sidekiq/failures/middleware.rb
+++ b/lib/sidekiq/failures/middleware.rb
@@ -64,7 +64,7 @@ module Sidekiq
       end
 
       def exhausted?
-        !retriable? || retry_count >= max_retries
+        !retriable? || (retry_count + 1) >= max_retries
       end
 
       def retriable?


### PR DESCRIPTION
I noticed errors were not being reported when I used the `:exhausted` option. Since the [retry_count](https://github.com/mperham/sidekiq/blob/b53224955440cce657c282db9cfed4f3dafc5490/lib/sidekiq/job_retry.rb#L158) for Sidekiq starts at 0, if you have the retry count option manually set in your job it will never trigger an error to be reported when the retries are exhausted. 

Let me know what you think! 