### PR TITLE
Guard against error_message being nil

### DIFF
--- a/lib/sidekiq/failures/views/failures.erb
+++ b/lib/sidekiq/failures/views/failures.erb
@@ -45,7 +45,7 @@
           </td>
           <td style="overflow: auto; padding: 10px;">
             <a class="backtrace" href="#" onclick="$(this).next().toggle(); return false">
-              <%= h entry['error_class'] %>: <%= h entry['error_message'].size > 500 ? entry['error_message'][0..500] + '...' : entry['error_message'] %>
+              <%= h entry['error_class'] %>: <%= h entry['error_message'].to_s.size > 500 ? entry['error_message'][0..500] + '...' : entry['error_message'] %>
             </a>
             <pre style="display: none; background: none; border: 0; width: 100%; max-height: 30em; font-size: 0.8em; white-space: nowrap; overflow: auto;">
               <%= entry['error_backtrace'].join("<br />") if entry['error_backtrace'] %>

--- a/test/web_extension_test.rb
+++ b/test/web_extension_test.rb
@@ -138,6 +138,14 @@ module Sidekiq
         last_response.status.must_equal 200
         last_response.body.must_match(/No failed jobs found/)
       end
+
+      it 'can handle failures with nil error_message' do
+        create_sample_failure(error_message: nil)
+
+        get '/failures'
+
+        last_response.status.must_equal 200
+      end
     end
 
     describe 'when there is failure' do


### PR DESCRIPTION
In the event that a failure has no error_message, the sidekiq failures
page will throw an exception:

```
(erb):48:in `block in _erb': undefined method `size' for nil:NilClass (NoMethodError)
    from (erb):31:in `each'
    from (erb):31:in `_erb'
    from /usr/local/rbenv/versions/2.5.1/lib/ruby/2.5.0/erb.rb:876:in `eval'
    from /usr/local/rbenv/versions/2.5.1/lib/ruby/2.5.0/erb.rb:876:in `result'
    from gems/sidekiq-5.2.7/lib/sidekiq/web/action.rb:83:in `_erb'
    from gems/sidekiq-5.2.7/lib/sidekiq/web/action.rb:54:in `erb'
    from gems/sidekiq-5.2.7/lib/sidekiq/web/action.rb:63:in `render'
    from gems/sidekiq-failures-1.0.0/lib/sidekiq/failures/web_extension.rb:25:in `block in registered'
    from gems/sidekiq-5.2.7/lib/sidekiq/web/application.rb:287:in `instance_exec'
    from gems/sidekiq-5.2.7/lib/sidekiq/web/application.rb:287:in `block in call'
    from gems/sidekiq-5.2.7/lib/sidekiq/web/application.rb:283:in `catch'
    from gems/sidekiq-5.2.7/lib/sidekiq/web/application.rb:283:in `call'
    from gems/rack-protection-2.0.5/lib/rack/protection/xss_header.rb:18:in `call'
    from gems/rack-protection-2.0.5/lib/rack/protection/base.rb:50:in `call'
    from gems/rack-protection-2.0.5/lib/rack/protection/base.rb:50:in `call'
    from gems/rack-protection-2.0.5/lib/rack/protection/path_traversal.rb:16:in `call'
    from gems/rack-protection-2.0.5/lib/rack/protection/json_csrf.rb:26:in `call'
    from gems/rack-protection-2.0.5/lib/rack/protection/base.rb:50:in `call'
    from gems/rack-protection-2.0.5/lib/rack/protection/base.rb:50:in `call'
    from gems/rack-protection-2.0.5/lib/rack/protection/frame_options.rb:31:in `call'
    from gems/rack-protection-2.0.5/lib/rack/protection/base.rb:50:in `call'
    from gems/rack-2.0.7/lib/rack/session/abstract/id.rb:232:in `context'
    from gems/rack-2.0.7/lib/rack/session/abstract/id.rb:226:in `call'
    from gems/rack-2.0.7/lib/rack/urlmap.rb:68:in `block in call'
    from gems/rack-2.0.7/lib/rack/urlmap.rb:53:in `each'
    from gems/rack-2.0.7/lib/rack/urlmap.rb:53:in `call'
    from gems/rack-2.0.7/lib/rack/builder.rb:153:in `call'
    from gems/sidekiq-5.2.7/lib/sidekiq/web.rb:103:in `call'
    from gems/sidekiq-5.2.7/lib/sidekiq/web.rb:108:in `call'
```

This is because we're trying to call `.size` on `nil`. This PR first
calls `to_s` on the error_message, ensuring that we'll always have
something that can respond to `.size`.