### PR TITLE
Get tests passing again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ sudo: false
 cache: bundler
 services:
   - redis-server
-before_install:
-  - gem install bundler
-  - gem update bundler
 rvm:
   - jruby-9.1.6.0
   - 2.2.4

--- a/sidekiq-failures.gemspec
+++ b/sidekiq-failures.gemspec
@@ -18,6 +18,13 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "sidekiq", ">= 4.0.0"
 
+  # Redis 4.X is incompatible with Ruby < 2.3, but the Ruby version constraint
+  # wasn't added until 4.1.2, meaning you can get an incompatible version of the
+  # redis gem when running Ruby 2.2 without this constraint.
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.3.0")
+    gem.add_dependency "redis", "< 4.0"
+  end
+
   gem.add_development_dependency "minitest"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rack-test"

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -6,7 +6,7 @@ module Sidekiq
       before do
         $invokes = 0
         @boss = MiniTest::Mock.new
-        2.times { @boss.expect(:options, {:queues => ['default'] }, []) }
+        num_options_calls.times { @boss.expect(:options, {:queues => ['default'] }, []) }
         @processor = ::Sidekiq::Processor.new(@boss)
         Sidekiq.server_middleware {|chain| chain.add Sidekiq::Failures::Middleware }
         Sidekiq.redis = REDIS
@@ -232,7 +232,7 @@ module Sidekiq
 
         3.times do
           boss = MiniTest::Mock.new
-          2.times { boss.expect(:options, {:queues => ['default'] }, []) }
+          num_options_calls.times { boss.expect(:options, {:queues => ['default'] }, []) }
           processor = ::Sidekiq::Processor.new(boss)
 
           actor = MiniTest::Mock.new
@@ -277,6 +277,14 @@ module Sidekiq
 
       def create_work(msg)
         Sidekiq::BasicFetch::UnitOfWork.new('default', Sidekiq.dump_json(msg))
+      end
+
+      def num_options_calls
+        if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('5.0.3')
+          3
+        else
+          2
+        end
       end
     end
   end

--- a/test/web_extension_test.rb
+++ b/test/web_extension_test.rb
@@ -5,7 +5,7 @@ module Sidekiq
   describe "WebExtension" do
     include Rack::Test::Methods
 
-    TOKEN = rand(2**128-1).freeze
+    TOKEN = SecureRandom.base64(32).freeze
 
     def app
       Sidekiq::Web


### PR DESCRIPTION
Tests are currently failing for a multitude of reasons, and this PR addresses all of them.

* A change in Sidekiq::Processor.initialize now calls `options` on the manager object 3 times instead of 2, meaning we need to vary our mock expectation depending on the sidekiq version
* We currently set our CSRF token in tests to a bigint, but rack-protection expects it to be a string. This changes the generation of the token to match what rack-protection does.
* `gem install bundler` in our test setup will now try to install bundler 2.0, which doesn't support Ruby 2.2. The pre_install steps didn't really seem to be necessary, so they've been removed.
* When running the Ruby 2.2/Sidekiq 5 combo, it's possible to get a redis gem version between 4.0 and 4.1.1 that is incompatible with Ruby 2.2. This adds a version constraint to the gemspec when running older than Ruby 2.3

Once this goes through, I'll followup with another PR to update the versions in our Travis matrix