### PR TITLE
fix POST /filter/failures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,9 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'sidekiq', ENV['SIDEKIQ_VERSION'] if ENV['SIDEKIQ_VERSION']
+
+# to test Pro-specific functionality, set SIDEKIQ_PRO_CREDS on `bundle install`
+# and SIDEKIQ_PRO_VERSION on `bundle install` and `rake test`
+source "https://#{ENV['SIDEKIQ_PRO_CREDS']}@enterprise.contribsys.com/" do    
+    gem 'sidekiq-pro', ENV['SIDEKIQ_PRO_VERSION'] if ENV['SIDEKIQ_PRO_VERSION']
+end if ENV['SIDEKIQ_PRO_VERSION']

--- a/lib/sidekiq/failures/views/failures.erb
+++ b/lib/sidekiq/failures/views/failures.erb
@@ -2,7 +2,7 @@
   <div class="col-sm-5">
     <h3><%= t('FailedJobs') %></h3>
   </div>
-  <% if @failures.size > 0 && @total_size > @count %>
+  <% if @failures.count > 0 && @total_size > @count %>
     <div class="col-sm-4">
       <%= erb :_paging, :locals => { :url => "#{root_path}failures" } %>
     </div>
@@ -10,7 +10,7 @@
   <%= filtering('failures') if respond_to?(:filtering) %>
 </header>
 
-<% if @failures.size > 0 %>
+<% if @failures.count > 0 %>
   <form action="<%= root_path %>failures" method="post">
     <%= csrf_tag if respond_to?(:csrf_tag) %>
     <table class="table table-striped table-bordered table-white">
@@ -70,7 +70,7 @@
     <input class="btn btn-danger btn-xs pull-right" type="submit" name="retry" value="<%= t('RetryAll') %>" data-confirm="<%= t('AreYouSure') %>" />
   </form>
 
-  <% if @failures.size > 0 && @total_size > @count %>
+  <% if @failures.count > 0 && @total_size > @count %>
     <div class="col-sm-4">
       <%= erb :_paging, :locals => { :url => "#{root_path}failures" } %>
     </div>

--- a/lib/sidekiq/failures/web_extension.rb
+++ b/lib/sidekiq/failures/web_extension.rb
@@ -86,7 +86,7 @@ module Sidekiq
         app.post '/filter/failures' do
           @failures = Sidekiq::Failures::FailureSet.new.scan("*#{params[:substr]}*")
           @current_page = 1
-          @count = @total_size = @failures.size
+          @count = @total_size = @failures.count          
           render(:erb, File.read(File.join(view_path, "failures.erb")))
         end
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,7 @@ require "minitest/mock"
 require "rack/test"
 
 require "sidekiq"
+require "sidekiq-pro" if ENV['SIDEKIQ_PRO_VERSION']
 require "sidekiq-failures"
 require "sidekiq/processor"
 require "sidekiq/fetch"


### PR DESCRIPTION
This is a Pro-only feature apparently. Adding sidekiq-pro and running the test revealed the same error I was seeing in production (see below).

tl;dr: `Enumerator#size` will return `nil` if the value can't be lazily calculated. `count` returns zero like you'd expect.

```
  1) Error:
WebExtension::when there is failure#test_0005_can filter failure:
NoMethodError: undefined method `>' for nil:NilClass
    (erb):5:in `_erb'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/2.6.0/erb.rb:901:in `eval'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/2.6.0/erb.rb:901:in `result'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.7/lib/sidekiq/web/action.rb:87:in `_erb'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.7/lib/sidekiq/web/action.rb:58:in `erb'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.7/lib/sidekiq/web/action.rb:67:in `render'
    /Users/bortega/projects/github/sidekiq-failures/lib/sidekiq/failures/web_extension.rb:90:in `block in registered'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.7/lib/sidekiq/web/application.rb:296:in `instance_exec'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.7/lib/sidekiq/web/application.rb:296:in `block in call'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.7/lib/sidekiq/web/application.rb:294:in `catch'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.7/lib/sidekiq/web/application.rb:294:in `call'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/rack-protection-2.0.8.1/lib/rack/protection/xss_header.rb:18:in `call'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/rack-protection-2.0.8.1/lib/rack/protection/base.rb:50:in `call'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/rack-protection-2.0.8.1/lib/rack/protection/base.rb:50:in `call'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/rack-protection-2.0.8.1/lib/rack/protection/path_traversal.rb:16:in `call'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/rack-protection-2.0.8.1/lib/rack/protection/json_csrf.rb:26:in `call'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/rack-protection-2.0.8.1/lib/rack/protection/base.rb:50:in `call'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/rack-protection-2.0.8.1/lib/rack/protection/base.rb:50:in `call'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/rack-protection-2.0.8.1/lib/rack/protection/frame_options.rb:31:in `call'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/rack-protection-2.0.8.1/lib/rack/protection/base.rb:50:in `call'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/rack-2.2.2/lib/rack/session/abstract/id.rb:266:in `context'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/rack-2.2.2/lib/rack/session/abstract/id.rb:260:in `call'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/rack-2.2.2/lib/rack/urlmap.rb:74:in `block in call'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/rack-2.2.2/lib/rack/urlmap.rb:58:in `each'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/rack-2.2.2/lib/rack/urlmap.rb:58:in `call'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/rack-2.2.2/lib/rack/builder.rb:244:in `call'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.7/lib/sidekiq/web.rb:104:in `call'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.7/lib/sidekiq/web.rb:109:in `call'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/rack-test-1.1.0/lib/rack/mock_session.rb:29:in `request'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/rack-test-1.1.0/lib/rack/test.rb:266:in `process_request'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/rack-test-1.1.0/lib/rack/test.rb:129:in `custom_request'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/rack-test-1.1.0/lib/rack/test.rb:66:in `post'
    /Users/bortega/.asdf/installs/ruby/2.6.3/lib/ruby/2.6.0/forwardable.rb:230:in `post'
    /Users/bortega/projects/github/sidekiq-failures/test/web_extension_test.rb:187:in `block (3 levels) in <module:Sidekiq>'
```