### PR TITLE
CI: Avoid double installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        bundler-cache: true
+        bundler-cache: true # 'bundle install' and cache gems
         ruby-version: ${{ matrix.ruby }}
-    - name: Install dependencies
-      run: bundle install
     - name: Run tests
       run: bundle exec rake


### PR DESCRIPTION
Commented in the YAML what the bundler-cache: true does.