### PR TITLE
gemspec: Remove unused executables, test_files

### DIFF
--- a/sidekiq-failures.gemspec
+++ b/sidekiq-failures.gemspec
@@ -10,8 +10,6 @@ Gem::Specification.new do |gem|
   gem.license       = "MIT"
 
   gem.files         = `git ls-files`.split($\)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "sidekiq-failures"
   gem.require_paths = ["lib"]
   gem.version       = Sidekiq::Failures::VERSION


### PR DESCRIPTION
This gem exposes 0 executables, and the test_files directive is not used by RubyGems.