### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.6, 2.7, 3.0]
+        ruby: [2.6, 2.7, '3.0', 3.1]
         sidekiq: [4.2, 5.2, 6.2]
     services:
       redis:


### PR DESCRIPTION
In addition to adding Ruby 3.1 to the CI matrix, this PR quotes the 3.0 in the config.

Without this quoting, 3.0 gets truncated to 3.  This loads the latest Ruby 3 version - 3.1.0 - contrary to the intention that a 3.0.x version be loaded.  By quoting we ensure that the latest 3.0.x version is loaded for this matrix entry.