### PR TITLE
Sanitize failure error and backtrace on failure details page

### DIFF
--- a/lib/sidekiq/failures/views/failure.erb
+++ b/lib/sidekiq/failures/views/failure.erb
@@ -6,12 +6,12 @@
     <tr>
       <th><%= t('ErrorClass') %></th>
       <td>
-        <code><%= @failure['error_class'] %></code>
+        <code><%= h @failure['error_class'] %></code>
       </td>
     </tr>
     <tr>
       <th><%= t('ErrorMessage') %></th>
-      <td><%= @failure['error_message'] %></td>
+      <td><%= h @failure['error_message'] %></td>
     </tr>
     <% if !@failure['error_backtrace'].nil? %>
       <tr>


### PR DESCRIPTION
We're not currently sanitizing the error on the failure details page, which can lead to issues like https://github.com/mhfs/sidekiq-failures/issues/143.

Resolves https://github.com/mhfs/sidekiq-failures/issues/143