### PR TITLE
Clear failures set in reset_failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,18 @@ influenced by `failures_max_count`.
 Sidekiq::Failures.count
 ```
 
-### Reset Failures
+### Reset and clear Failures
 
 Gives a convenient way of reseting Sidekiq Failure stored failed jobs programmatically.
-Takes an options hash and if the `counter` key is present also resets Sidekiq own failed stats.
 
 ```ruby
-Sidekiq::Failures.reset_failures
+Sidekiq::Failures.clear_failures
+```
+
+To reset Sidekiq own failed *stats*.
+
+```ruby
+Sidekiq::Failures.reset_failure_count
 ```
 
 ## Dependencies

--- a/lib/sidekiq/failures.rb
+++ b/lib/sidekiq/failures.rb
@@ -59,7 +59,17 @@ module Sidekiq
     LIST_KEY = :failed
 
     def self.reset_failures
+      warn "NOTE: Sidekiq::Failures.reset_failures is deprecated; use Sidekiq::Failures.reset_failure_count instead."
+
+      reset_failure_count
+    end
+
+    def self.reset_failure_count
       Sidekiq.redis { |c| c.set("stat:failed", 0) }
+    end
+
+    def self.clear_failures
+      FailureSet.new.clear
     end
 
     def self.count


### PR DESCRIPTION
```ruby
[8] pry(main)> Sidekiq::Failures.count
=> 4
[9] pry(main)> Sidekiq::Failures.reset_failures
=> [1, "OK"]
[10] pry(main)> Sidekiq::Failures.count
=> 0
```

Fixes #126