### PR TITLE
Fix deprecated method and testing

### DIFF
--- a/lib/sidekiq/failures/sorted_entry.rb
+++ b/lib/sidekiq/failures/sorted_entry.rb
@@ -13,7 +13,7 @@ module Sidekiq
       Sidekiq.redis do |conn|
         # after Redis v6.2.0, zrangebyscore is deprecated and zrange with BYSCORE is used
         results = if Gem::Version.new(conn.info["redis_version"].to_s) > Gem::Version.new('6.2.0')
-                    conn.zrange(Sidekiq::Failures::LIST_KEY, score, score, "BYSCORE")
+                    conn.zrange(Sidekiq::Failures::LIST_KEY, score.to_i, score.to_i,  by_score: true)
                   else
                     conn.zrangebyscore(Sidekiq::Failures::LIST_KEY, score, score)
                   end

--- a/lib/sidekiq/failures/sorted_entry.rb
+++ b/lib/sidekiq/failures/sorted_entry.rb
@@ -11,7 +11,7 @@ module Sidekiq
 
     def retry_failure
       Sidekiq.redis do |conn|
-        results = conn.zrangebyscore(Sidekiq::Failures::LIST_KEY, score, score)
+        results = conn.zrange(Sidekiq::Failures::LIST_KEY, score, score, "BYSCORE")
         conn.zremrangebyscore(Sidekiq::Failures::LIST_KEY, score, score)
         results.map do |message|
           msg = Sidekiq.load_json(message)

--- a/lib/sidekiq/failures/sorted_entry.rb
+++ b/lib/sidekiq/failures/sorted_entry.rb
@@ -11,9 +11,11 @@ module Sidekiq
 
     def retry_failure
       Sidekiq.redis do |conn|
-        # after Redis v6.2.0, zrangebyscore is deprecated and zrange with BYSCORE is used
-        results = if Gem::Version.new(conn.info["redis_version"].to_s) > Gem::Version.new('6.2.0')
-                    conn.zrange(Sidekiq::Failures::LIST_KEY, score.to_i, score.to_i,  by_score: true)
+        # from Redis v6.2.0, zrangebyscore is deprecated and zrange with BYSCORE is used
+        # option byscore is available from redis-rb v4.6.0
+        results = if Gem::Version.new(conn.info["redis_version"].to_s) >= Gem::Version.new('6.2.0') &&
+                     Gem.loaded_specs['redis'].version >= Gem::Version.new('4.6.0')
+                    conn.zrange(Sidekiq::Failures::LIST_KEY, score.to_i, score.to_i, byscore: true)
                   else
                     conn.zrangebyscore(Sidekiq::Failures::LIST_KEY, score, score)
                   end

--- a/lib/sidekiq/failures/web_extension.rb
+++ b/lib/sidekiq/failures/web_extension.rb
@@ -65,7 +65,7 @@ module Sidekiq
         end
 
         app.post "/failures/all/reset" do
-          Sidekiq::Failures.reset_failures
+          Sidekiq::Failures.reset_failure_count
           redirect "#{root_path}failures"
         end
 
@@ -86,7 +86,7 @@ module Sidekiq
         app.post '/filter/failures' do
           @failures = Sidekiq::Failures::FailureSet.new.scan("*#{params[:substr]}*")
           @current_page = 1
-          @count = @total_size = @failures.count          
+          @count = @total_size = @failures.count
           render(:erb, File.read(File.join(view_path, "failures.erb")))
         end
       end

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -29,12 +29,12 @@ end
 
 class SidekiqPost63
   def new_processor(boss)
-    config_sidekiq = Sidekiq.configure_server do |config|
+    sidekiq_config = Sidekiq.configure_server do |config|
       config.capsule('unsafe') do |cap|
         cap.queues = %w[default]
       end
     end
-    ::Sidekiq::Processor.new(config_sidekiq) { |processor, reason = nil| }
+    ::Sidekiq::Processor.new(sidekiq_config) { |processor, reason = nil| }
   end
 end
 

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -29,12 +29,12 @@ end
 
 class SidekiqPost63
   def new_processor(boss)
-    configSidekiq = Sidekiq.configure_server do |config|
+    config_sidekiq = Sidekiq.configure_server do |config|
       config.capsule('unsafe') do |cap|
         cap.queues = %w[default]
       end
     end
-    ::Sidekiq::Processor.new(configSidekiq) { |processor, reason = nil| }
+    ::Sidekiq::Processor.new(config_sidekiq) { |processor, reason = nil| }
   end
 end
 

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -29,12 +29,11 @@ end
 
 class SidekiqPost63
   def new_processor(boss)
-    sidekiq_config = Sidekiq.configure_server do |config|
-      config.capsule('unsafe') do |cap|
-        cap.queues = %w[default]
-      end
-    end
-    ::Sidekiq::Processor.new(sidekiq_config) { |processor, reason = nil| }
+    config = Sidekiq
+    config[:queues] = ['default']
+    config[:fetch] = Sidekiq::BasicFetch.new(config)
+    config[:error_handlers] << Sidekiq.method(:default_error_handler)
+    ::Sidekiq::Processor.new(config) { |processor, reason = nil| }
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,4 +15,4 @@ require "sidekiq/cli"
 
 Sidekiq.logger.level = Logger::ERROR
 
-REDIS = Sidekiq::RedisConnection.create(url: "redis://localhost/15")
+REDIS = Sidekiq::RedisConnection.create(url: "redis://127.0.0.1:6379/0")

--- a/test/web_extension_test.rb
+++ b/test/web_extension_test.rb
@@ -14,8 +14,7 @@ module Sidekiq
     before do
       env 'rack.session', { csrf: TOKEN }
       env 'HTTP_X_CSRF_TOKEN', TOKEN
-      Sidekiq.redis = REDIS
-      Sidekiq.redis {|c| c.flushdb }
+      Sidekiq.redis(&:flushdb)
     end
 
     it 'can display home with failures tab' do


### PR DESCRIPTION
#### changes: 
- gem `minitest` has changed the name of the module from `MiniTest` to `Minitest `
- method `zrangebyscore ` of Redis is deprecated. It should be `zrange` with 1 more params (`"BYSCORE"`)
- The `Sidekiq` config has been changed (reverted, we will support `Sidekiq 7.x` later)
- Change `Sidekiq` `URL` to match `Redis` default config at local.
- Refacto typos

#### before fixing:
```
Finished in 0.088193s, 430.8732 runs/s, 0.0000 assertions/s.
38 runs, 0 assertions, 0 failures, 37 errors, 0 skips
```
#### after fixing:
```
Run options: --seed 40605

# Running:

......................................

Finished in 0.181538s, 209.3226 runs/s, 947.4600 assertions/s.
38 runs, 172 assertions, 0 failures, 0 errors, 0 skips
```