### PR TITLE
Sidekiq 8 Compatiblity

### DIFF
--- a/lib/sidekiq/failures/views/failures.erb
+++ b/lib/sidekiq/failures/views/failures.erb
@@ -36,7 +36,7 @@
             </label>
           </td>
           <td>
-            <a href="<%= root_path %>failures/<%= job_params(entry.item, entry.score) %>"><%= safe_relative_time(entry['failed_at']) %></a>
+            <a href="<%= root_path %>failures/<%= job_params(entry.item, entry.score) %>"><%= relative_time(Time.at(entry['failed_at'])) %></a>
           </td>
           <td>
             <a href="<%= root_path %>queues/<%= entry.queue %>"><%= entry.queue %></a>

--- a/lib/sidekiq/failures/web_extension.rb
+++ b/lib/sidekiq/failures/web_extension.rb
@@ -1,50 +1,35 @@
 module Sidekiq
   module Failures
     module WebExtension
-
       def self.registered(app)
         view_path = File.join(File.expand_path("..", __FILE__), "views")
 
-        app.helpers do
-          def safe_relative_time(time)
-            return unless time
-
-            time = if time.is_a?(Numeric)
-              Time.at(time)
-            else
-              Time.parse(time)
-            end
-
-            relative_time(time)
-          end
-        end
-
         app.get "/failures" do
           @count = (params[:count] || 25).to_i
-          (@current_page, @total_size, @failures) = page(LIST_KEY, params[:page], @count, :reverse => true)
-          @failures = @failures.map {|msg, score| Sidekiq::SortedEntry.new(nil, score, msg) }
+          (@current_page, @total_size, @failures) = page(LIST_KEY, params[:page], @count, reverse: true)
+          @failures = @failures.map { |msg, score| Sidekiq::SortedEntry.new(nil, score, msg) }
 
           render(:erb, File.read(File.join(view_path, "failures.erb")))
         end
 
         app.get "/failures/:key" do
-          halt 404 unless params['key']
+          halt 404 unless params["key"]
 
-          @failure = FailureSet.new.fetch(*parse_params(params['key'])).first
+          @failure = FailureSet.new.fetch(*parse_params(params["key"])).first
           redirect "#{root_path}failures" if @failure.nil?
           render(:erb, File.read(File.join(view_path, "failure.erb")))
         end
 
         app.post "/failures" do
-          halt 404 unless params['key']
+          halt 404 unless params["key"]
 
-          params['key'].each do |key|
+          params["key"].each do |key|
             job = FailureSet.new.fetch(*parse_params(key)).first
             next unless job
 
-            if params['retry']
+            if params["retry"]
               job.retry_failure
-            elsif params['delete']
+            elsif params["delete"]
               job.delete
             end
           end
@@ -53,13 +38,13 @@ module Sidekiq
         end
 
         app.post "/failures/:key" do
-          halt 404 unless params['key']
+          halt 404 unless params["key"]
 
-          job = FailureSet.new.fetch(*parse_params(params['key'])).first
+          job = FailureSet.new.fetch(*parse_params(params["key"])).first
           if job
-            if params['retry']
+            if params["retry"]
               job.retry_failure
-            elsif params['delete']
+            elsif params["delete"]
               job.delete
             end
           end
@@ -81,11 +66,11 @@ module Sidekiq
           redirect "#{root_path}failures"
         end
 
-        app.get '/filter/failures' do
+        app.get "/filter/failures" do
           redirect "#{root_path}failures"
         end
 
-        app.post '/filter/failures' do
+        app.post "/filter/failures" do
           @failures = Sidekiq::Failures::FailureSet.new.scan("*#{params[:substr]}*")
           @current_page = 1
           @count = @total_size = @failures.count


### PR DESCRIPTION
This is a quick and dirty patch to get it working with Sidekiq 8 again. There are probably more improvements to make.

- Replaced `Sidekiq::Web.register` with new `Sidekiq::Web.configure` method.
- Removed `safe_relative_time` helper, as it was throwing an error and I didn't have time to figure out how to register helpers in 8.0. I'm not sure if it's needed. 
- Many of the other line changes are just standardrb auto-formatting on save.

I'm happy to do more work on this, but just didn't have time now and I figured a quick fix is better than no fix. If this PR doesn't get merged, and you want to install the gem off my repo for now, you're welcome to. I can't promise it'll be online forever though.